### PR TITLE
Fixed typo in line 162. focus ws10

### DIFF
--- a/config
+++ b/config
@@ -159,7 +159,7 @@ bindsym $mod+$alt+6 move container to workspace $ws6; workspace $ws6
 bindsym $mod+$alt+7 move container to workspace $ws7; workspace $ws7
 bindsym $mod+$alt+8 move container to workspace $ws8; workspace $ws8
 bindsym $mod+$alt+9 move container to workspace $ws9; workspace $ws9
-bindsym $mod+$alt+0 move container to workspace $ws10; workspace $ws1
+bindsym $mod+$alt+0 move container to workspace $ws10; workspace $ws10
 bindsym $mod+$alt+Ctrl+1 move container to workspace $ws11; workspace $ws11
 bindsym $mod+$alt+Ctrl+2 move container to workspace $ws12; workspace $ws12
 bindsym $mod+$alt+Ctrl+3 move container to workspace $ws13; workspace $ws13


### PR DESCRIPTION
Focus was incorrectly set to ws1 in line 162, after moving container to ws10