### PR TITLE
Add config to move workspaces to different outputs using arrow keys

### DIFF
--- a/config
+++ b/config
@@ -81,6 +81,12 @@ bindsym $mod+Shift+j move down
 bindsym $mod+Shift+k move up
 bindsym $mod+Shift+l move right
 
+# move workspaces to outputs
+bindsym $mod+Ctrl+Shift+Left move workspace to output left
+bindsym $mod+Ctrl+Shift+Down move workspace to output down
+bindsym $mod+Ctrl+Shift+Up move workspace to output up
+bindsym $mod+Ctrl+Shift+Right move workspace to output right
+
 # toggle split orientation
 bindsym $mod+BackSpace split toggle
 


### PR DESCRIPTION
What it says on the tin. Allows you to shift your current workspace up, down, left and right to another screen using the arrow keys.