### PR TITLE
Update deprecated border setting

### DIFF
--- a/config
+++ b/config
@@ -248,8 +248,8 @@ mode "Resize Mode" {
 bindsym $mod+r mode "Resize Mode"
 
 # Disable titlebar
-new_window pixel 1
-new_float pixel 1
+default_border pixel 1
+default_floating_border pixel 1
 
 # Specify the distance between windows in pixels. (i3-gaps)
 gaps inner 5


### PR DESCRIPTION
According to the i3 user guide https://i3wm.org/docs/userguide.html#_default_border_style_for_new_windows: "Please note that new_window and new_float have been deprecated in favor of the above options and will be removed in a future release. We strongly recommend using the new options instead."