### PR TITLE
Add keybindings for 'next free workspace' feature

### DIFF
--- a/config
+++ b/config
@@ -171,7 +171,7 @@ bindsym $mod+Shift+Tab workspace prev
 ## Navigate // Previous Workspace // <><Alt> ← ##
 bindsym $mod+$alt+Left workspace prev
 
-## Navigate // Next Free Workspace // <> `
+## Navigate // Next Free Workspace // <> ` ##
 bindsym $mod+grave exec --no-startup-id /usr/share/i3xrocks/next-workspace --startnum 1
 
 ## Navigate // Scratchpad // <><Ctrl> a ##
@@ -274,7 +274,7 @@ bindsym $mod+$alt+Ctrl+$ws7_key move container to workspace number $ws17; worksp
 bindsym $mod+$alt+Ctrl+$ws8_key move container to workspace number $ws18; workspace number $ws18
 bindsym $mod+$alt+Ctrl+$ws9_key move container to workspace number $ws19; workspace number $ws19
 
-## Modify // Move Window to Next Free Workspace // <><Shift> `
+## Modify // Move Window to Next Free Workspace // <><Shift> ` ##
 bindsym $mod+shift+grave exec --no-startup-id /usr/share/i3xrocks/next-workspace --startnum 1 --move-window-and-follow
 
 # Use Mouse+$mod to drag floating windows to their wanted position

--- a/config
+++ b/config
@@ -171,6 +171,9 @@ bindsym $mod+Shift+Tab workspace prev
 ## Navigate // Previous Workspace // <><Alt> ← ##
 bindsym $mod+$alt+Left workspace prev
 
+## Navigate // Next Free Workspace // <> `
+bindsym $mod+grave exec --no-startup-id /usr/share/i3xrocks/next-workspace --startnum 1
+
 ## Navigate // Scratchpad // <><Ctrl> a ##
 bindsym $mod+Ctrl+a scratchpad show
 
@@ -270,6 +273,9 @@ bindsym $mod+$alt+Ctrl+$ws6_key move container to workspace number $ws16; worksp
 bindsym $mod+$alt+Ctrl+$ws7_key move container to workspace number $ws17; workspace number $ws17
 bindsym $mod+$alt+Ctrl+$ws8_key move container to workspace number $ws18; workspace number $ws18
 bindsym $mod+$alt+Ctrl+$ws9_key move container to workspace number $ws19; workspace number $ws19
+
+## Modify // Move Window to Next Free Workspace // <><Shift> `
+bindsym $mod+shift+grave exec --no-startup-id /usr/share/i3xrocks/next-workspace --startnum 1 --move-window-and-follow
 
 # Use Mouse+$mod to drag floating windows to their wanted position
 floating_modifier $mod

--- a/config
+++ b/config
@@ -274,8 +274,8 @@ bindsym $mod+$alt+Ctrl+$ws7_key move container to workspace number $ws17; worksp
 bindsym $mod+$alt+Ctrl+$ws8_key move container to workspace number $ws18; workspace number $ws18
 bindsym $mod+$alt+Ctrl+$ws9_key move container to workspace number $ws19; workspace number $ws19
 
-## Modify // Move Window to Next Free Workspace // <><Shift> ` ##
-bindsym $mod+shift+grave exec --no-startup-id /usr/share/i3xrocks/next-workspace --startnum 1 --move-window-and-follow
+## Modify // Carry Window to Next Free Workspace // <><Shift> ` ##
+bindsym $mod+$alt+grave exec --no-startup-id /usr/share/i3xrocks/next-workspace --startnum 1 --move-window-and-follow
 
 # Use Mouse+$mod to drag floating windows to their wanted position
 floating_modifier $mod

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+regolith-i3-gaps-config (2.5.19-1) bionic; urgency=medium
+
+  [ Ken Gilmer ]
+  * Add keybindings for 'next free workspace' feature.
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Mon, 20 Jul 2020 06:48:24 -0700
+
 regolith-i3-gaps-config (2.4.18-1) bionic; urgency=medium
 
   [ Will Winder ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-regolith-i3-gaps-config (2.5.19-1) bionic; urgency=medium
+regolith-i3-gaps-config (2.5.0-1) bionic; urgency=medium
 
   [ Ken Gilmer ]
   * Add keybindings for 'next free workspace' feature.


### PR DESCRIPTION
related to https://github.com/regolith-linux/regolith-i3xrocks-config/pull/69.

Adds "navigate to next free workspace" as super-`` and "move focused window to next free workspace" as super-shift-``

See https://github.com/regolith-linux/regolith-i3xrocks-config/pull/69 for context.