### PR TITLE
Revert to default i3 tray behaviour

### DIFF
--- a/config
+++ b/config
@@ -514,7 +514,6 @@ font $i3-wm.font
 set_from_resource $i3-wm.bar.position i3-wm.bar.position bottom
 set_from_resource $i3-wm.bar.font i3-wm.bar.font pango:Source Code Pro Medium 13, Material Design Icons 13
 set_from_resource $i3-wm.bar.separator i3-wm.bar.separator " "
-set_from_resource $i3-wm.bar.trayoutput i3-wm.bar.trayoutput none
 set_from_resource $i3-wm.bar.stripworkspacenumbers i3-wm.bar.stripworkspacenumbers yes
 
 # i3xrocks config file. Override this for a custom status bar generator.
@@ -526,7 +525,6 @@ bar {
   font $i3-wm.bar.font
   separator_symbol $i3-wm.bar.separator
   status_command $i3-wm.bar.status_command
-  tray_output $i3-wm.bar.trayoutput
   strip_workspace_numbers $i3-wm.bar.stripworkspacenumbers
 
   colors {


### PR DESCRIPTION
Two tray references removed, I think this is how to do it?

Fixes https://github.com/regolith-linux/regolith-desktop/issues/472