### PR TITLE
Resize mode: make cursor keybindings consistent with vim-style hjkl

### DIFF
--- a/config
+++ b/config
@@ -468,13 +468,13 @@ mode "Resize Mode" {
 
         ## Resize // Resize Window // ↑ ↓ ← → ##
         bindsym Left resize shrink width 6 px or 6 ppt
-        bindsym Down resize grow height 6 px or 6 ppt
-        bindsym Up resize shrink height 6 px or 6 ppt
+        bindsym Up resize grow height 6 px or 6 ppt
+        bindsym Down resize shrink height 6 px or 6 ppt
         bindsym Right resize grow width 6 px or 6 ppt
 
         bindsym Shift+Left resize shrink width 12 px or 12 ppt
-        bindsym Shift+Down resize grow height 12 px or 12 ppt
-        bindsym Shift+Up resize shrink height 12 px or 12 ppt
+        bindsym Shift+Up resize grow height 12 px or 12 ppt
+        bindsym Shift+Down resize shrink height 12 px or 12 ppt
         bindsym Shift+Right resize grow width 12 px or 12 ppt
 
         ## Resize // Resize Window // k j h l ##


### PR DESCRIPTION
In all other modes, h/j/k/l (vim-style) and Left/Down/Up/Right (cursor keys) are interchangeably usable. Only in resize mode, Down/Up are swapped the other way around which is a rather jarring user experience. This PR changes the cursor key bindings in resize mode to make it consistent with h/j/k/l (which do work as expected), with "Up" corresponding to grow and "Down" to shrink.