### PR TITLE
adding $mod+s for sound setting

### DIFF
--- a/config
+++ b/config
@@ -423,7 +423,7 @@ set_from_resource $i3-wm.program.bluetooth i3-wm.program.bluetooth gnome-control
 bindsym $mod+$i3-wm.binding.bluetooth exec $i3-wm.program.bluetooth
 
 ## Modify // Sound Settings // <> s ##
-set_from_resource $i3-wm.binding.sound i3-wm.binding.sound b
+set_from_resource $i3-wm.binding.sound i3-wm.binding.sound s
 set_from_resource $i3-wm.program.sound i3-wm.program.sound gnome-control-center --class=floating_window sound
 bindsym $mod+$i3-wm.binding.sound exec $i3-wm.program.sound
 

--- a/config
+++ b/config
@@ -422,6 +422,11 @@ set_from_resource $i3-wm.binding.bluetooth i3-wm.binding.bluetooth b
 set_from_resource $i3-wm.program.bluetooth i3-wm.program.bluetooth gnome-control-center --class=floating_window bluetooth
 bindsym $mod+$i3-wm.binding.bluetooth exec $i3-wm.program.bluetooth
 
+## Modify // Sound Settings // <> s ##
+set_from_resource $i3-wm.binding.sound i3-wm.binding.sound b
+set_from_resource $i3-wm.program.sound i3-wm.program.sound gnome-control-center --class=floating_window sound
+bindsym $mod+$i3-wm.binding.sound exec $i3-wm.program.sound
+
 ## Launch // File Browser // <><Shift> n ##
 set_from_resource $i3-wm.binding.files i3-wm.binding.files Shift+n
 set_from_resource $i3-wm.program.files i3-wm.program.files /usr/bin/nautilus --new-window


### PR DESCRIPTION
I constantly think Super+s should open my sound settings and get confused when it doesn't. With all the conference calls going on I find I very often need to go there and adjust input and outputs.