### PR TITLE
Pass parameter for timestamp to notification daemon

### DIFF
--- a/config
+++ b/config
@@ -88,7 +88,7 @@ set_from_resource $ws10_key i3-wm.workspace.10.key 0
 ###############################################################################
 # Rofication date & time format in Python format, see
 # https://docs.python.org/3/library/datetime.html
-# Defaults to locale default. Use empty string ("") for no timestamp
+# Defaults to no time information. Use "%x %X" for user locale.
 ###############################################################################
 set_from_resource $rofication_datetime_format rofication_datetime_format ""
 

--- a/config
+++ b/config
@@ -86,6 +86,13 @@ set_from_resource $ws9_key  i3-wm.workspace.09.key 9
 set_from_resource $ws10_key i3-wm.workspace.10.key 0
 
 ###############################################################################
+# Rofication date & time format in Python format, see
+# https://docs.python.org/3/library/datetime.html
+# Defaults to locale default. Use empty string ("") for no timestamp
+###############################################################################
+set_from_resource $rofication_datetime_format rofication_datetime_format ""
+
+###############################################################################
 # Launcher dialogs
 ###############################################################################
 
@@ -650,7 +657,7 @@ set_from_resource $i3-wm.program.compositor i3-wm.program.compositor /usr/share/
 exec_always --no-startup-id $i3-wm.program.compositor
 
 # Start Rofication for notifications
-set_from_resource $i3-wm.program.notifications i3-wm.program.notifications /usr/bin/rofication-daemon
+set_from_resource $i3-wm.program.notifications i3-wm.program.notifications /usr/bin/rofication-daemon --tsformat $rofication_datetime_format
 exec --no-startup-id $i3-wm.program.notifications
 
 # Launch first time user experience script


### PR DESCRIPTION
(requires https://github.com/regolith-linux/regolith-rofication/pull/15 being merged)

This PR just modifies the default config file to pass a datetime format to the notification daemon (by default, no datetime).
